### PR TITLE
Add sensible defaults for bg and cursor_bg

### DIFF
--- a/lua/neocolumn/config.lua
+++ b/lua/neocolumn/config.lua
@@ -1,5 +1,14 @@
 local M = {}
 
+local hex = function(n)
+  return string.format("#%06x", n)
+end
+
+local bg = function(n)
+  local color = vim.api.nvim_get_hl_by_name(n, true)
+  return hex(color.background)
+end
+
 M.defaults = {
     colors = {
         normal = "#7d7d7d",
@@ -15,8 +24,8 @@ M.defaults = {
         hint = "#1abc9c",
         hint_near = "#1abc9c",
         hint_far = "#32a6ba",
-        bg = "#303030",
-        cursor_bg = "#4d4d4d"
+        bg = bg('Normal'),
+        cursor_bg = bg('CursorLine')
     },
     exclude_filetypes = {
         "help",


### PR DESCRIPTION
Match the current background and cursor background of the users colorscheme by default.

This could potentially be expanded for other values but this was my use case

Closes https://github.com/parmeniong/neocolumn.nvim/issues/1