### PR TITLE
Exclude buftypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Here are the available options and their default values:
         "help",
         "man"
     },
+    -- neocolumn.nvim will be disabled in buffers with these buftypes
+    exclude_buftypes = {
+        "terminal"
+    },
     -- When enabled, the neocolumn will be colored depending on each line's diagnostics
     diagnostics = true,
     -- If `diagnostics` is `true` then diagnostic with a severity lower than this will be ignored

--- a/lua/neocolumn/config.lua
+++ b/lua/neocolumn/config.lua
@@ -14,6 +14,9 @@ M.defaults = {
         "help",
         "man"
     },
+    exclude_buftypes = {
+        "terminal"
+    },
     diagnostics = true,
     min_diagnostic_severity = vim.diagnostic.severity.HINT,
     max_line_length = 100,

--- a/lua/neocolumn/init.lua
+++ b/lua/neocolumn/init.lua
@@ -64,7 +64,9 @@ function M.setup(opts)
     }, {
         callback = function(event)
             local filetype = vim.bo.filetype
-            if vim.tbl_contains(config.opts.exclude_filetypes, filetype) then
+            local buftype = vim.bo.buftype
+            if vim.tbl_contains(config.opts.exclude_filetypes, filetype)
+                or vim.tbl_contains(config.opts.exclude_buftypes, buftype) then
                 if Ids[event.buf] then
                     for _, id in pairs(Ids[event.buf]) do
                         vim.api.nvim_buf_del_extmark(0, ns, id)


### PR DESCRIPTION
Added a config option named `exclude_buftypes` that disables the neocolumn in buffers with specific buftypes.